### PR TITLE
updated PDS3Label.java get() to return a node instead of  String. All…

### DIFF
--- a/src/main/java/gov/nasa/pds/imaging/generate/label/PDS3Label.java
+++ b/src/main/java/gov/nasa/pds/imaging/generate/label/PDS3Label.java
@@ -163,8 +163,11 @@ public class PDS3Label implements PDSObject {
       } else if (node instanceof ItemNode) {
       	Debugger.debug("++++ node(2) ------>\n" + ((ItemNode) node).toString());
       	Debugger.debug("++++ node(2) ------>\n" + StringEscapeUtils.escapeXml(((ItemNode) node).toString()));
-            
-          return StringEscapeUtils.escapeXml(((ItemNode) node).toString());
+      	Debugger.debug("++++ node(2) return as node -- "+key+" --> '" + StringEscapeUtils.escapeXml(((ItemNode) node).toString())+"'");
+      	return node; 
+      	// returnig this as node is consistent with all the other returns.
+      	// It allows other functions such as getUnits() to work properly
+        // return StringEscapeUtils.escapeXml(((ItemNode) node).toString());
       } else {
       	Debugger.debug("++ node(1) ------>\n" + node);
           return node;
@@ -362,6 +365,7 @@ public class PDS3Label implements PDSObject {
 
   @Override
   public final String getUnits(final String key) {
+	  Debugger.debug("PDS3label.getUnits "+key+" ");
 	  
 	  if (key.contains(".")) {
 		  return ((ItemNode) getNode(key)).getUnits();


### PR DESCRIPTION
The changes start at line 166 in gov/nasa/pds/imaging/generate/label/PDS3Label.java
The change is to return a node instead of a String. In all other cases a get() returns a node. Getting back a node allows getUnits() to work properly. 

This code fixes Velocity #174 issue in the zenhub M2020 PDS4 Development workspace. There is a template macro fix by N. Toole which addresses getting units in some specific situations. This fix makes all get() calls behave in  the same way by returning an ItemNode.

    