### PR TITLE
Documentation (gh-pages): minor typo correction

### DIFF
--- a/operate/index.html
+++ b/operate/index.html
@@ -202,7 +202,7 @@ ${JAVA_CMD} -Dpds.generate.parser.type=product-tools -jar ${GENERATE_JAR} &quot;
         </pre></div>
         
         
-<p><b><i>Windows Environmnet</i></b></p>
+<p><b><i>Windows Environment</i></b></p>
         
         
 <p>To change the underlying parser, set the <i>pds.generate.parser.type</i> Java system property to <i>product-tools</i> in the <i>pds-generate.bat</i> batch file as follows:


### PR DESCRIPTION
"Windows Environment" under the [Changing the Underlying Parser](https://nasa-pds.github.io/mi-label/operate/index.html#Changing_the_Underlying_Parser) section of the ["Operation"](https://nasa-pds.github.io/mi-label/operate/index.html) page of the GitHub Pages doc site was misspelled as "Windows Environm*ne*t". This pull request comprises a single commit that fixes that typo.