### PR TITLE
Improved exception handling and logging to support off-nominal use cases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,20 @@
       <artifactId>pds3-product-tools</artifactId>
       <version>${pds3-product-tools-version}</version>
     </dependency>
+	<!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
+	<dependency>
+	    <groupId>org.slf4j</groupId>
+	    <artifactId>slf4j-api</artifactId>
+	    <version>2.0.12</version>
+	    <scope>compile</scope>
+	</dependency>
+	<!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-simple -->
+	<dependency>
+	    <groupId>org.slf4j</groupId>
+	    <artifactId>slf4j-simple</artifactId>
+	    <version>2.0.12</version>
+	    <scope>compile</scope>
+	</dependency>
   </dependencies>
 
   <repositories>

--- a/src/main/java/gov/nasa/pds/imaging/generate/GenerateLauncher.java
+++ b/src/main/java/gov/nasa/pds/imaging/generate/GenerateLauncher.java
@@ -63,7 +63,7 @@ import org.slf4j.LoggerFactory;
 public class GenerateLauncher {
 
 	/** Logger. **/
-	private static Logger LOGGER = LoggerFactory.getLogger(GenerateLauncher.class.getName());
+	private static Logger LOGGER = LoggerFactory.getLogger(GenerateLauncher.class);
 
     private String basePath;
     private List<String> lblList;

--- a/src/main/java/gov/nasa/pds/imaging/generate/GenerateLauncher.java
+++ b/src/main/java/gov/nasa/pds/imaging/generate/GenerateLauncher.java
@@ -43,7 +43,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.logging.Logger;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -51,6 +50,8 @@ import org.apache.commons.cli.GnuParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.ParseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Class used as Command-line interface endpoint. Parses command-line arguments
@@ -62,7 +63,7 @@ import org.apache.commons.cli.ParseException;
 public class GenerateLauncher {
 
 	/** Logger. **/
-	private static Logger log = Logger.getLogger(GenerateLauncher.class.getName());
+	private static Logger LOGGER = LoggerFactory.getLogger(GenerateLauncher.class.getName());
 
     private String basePath;
     private List<String> lblList;
@@ -102,10 +103,10 @@ public class GenerateLauncher {
      * 
      */
     public final void displayVersion() {
-        System.err.println("\n" + ToolInfo.getName());
-        System.err.println(ToolInfo.getVersion());
-        System.err.println("Release Date: " + ToolInfo.getReleaseDate());
-        System.err.println(ToolInfo.getCopyright() + "\n");
+        LOGGER.info("\n" + ToolInfo.getName());
+        LOGGER.info(ToolInfo.getVersion());
+        LOGGER.info("Release Date: " + ToolInfo.getReleaseDate());
+        LOGGER.info(ToolInfo.getCopyright() + "\n");
     }
 
     public final void generate(){
@@ -199,9 +200,9 @@ public class GenerateLauncher {
 
         // Let's default to the one label if -p flag was specified,
         // otherwise loop through the lbl list
-        if (this.lblList == null) {
-          throw new InvalidOptionException("Missing -p or -l flags.  " + 
-                    "One or many PDS3 label must be specified.");
+        if (this.lblList.isEmpty()) {
+          throw new InvalidOptionException("Missing --pds3-label flag.  " + 
+                    "One or more PDS3 labels required.");
         } else {
         	String filepath;
         	PDS3Label pdsLabel;
@@ -260,7 +261,7 @@ public class GenerateLauncher {
 			        this.generatorList.add(new Generator(pdsObj, this.templateFile,
 			                outputFile, this.isXML));
         		} else {
-        			log.warning(lbl + " does not exist.");
+        			LOGGER.warn(lbl + " does not exist.");
         		}
         	}
         }
@@ -293,9 +294,11 @@ public class GenerateLauncher {
             launcher.query(commandline);
             launcher.generate();
             // launcher.closeHandlers();
+        } catch (InvalidOptionException e) {
+        	LOGGER.error(e.getMessage());
+            System.exit(1);
         } catch (final ParseException pEx) {
-            System.err.println("Command-line parse failure: "
-                    + pEx.getMessage());
+            LOGGER.error("Command-line parse failure: " + pEx.getMessage());
             System.exit(1);
         } catch (final Exception e) {
             e.printStackTrace();

--- a/src/main/java/gov/nasa/pds/imaging/generate/Generator.java
+++ b/src/main/java/gov/nasa/pds/imaging/generate/Generator.java
@@ -76,7 +76,7 @@ import gov.nasa.pds.imaging.generate.util.Debugger;
 
 public class Generator {
 	
-	private static final Logger LOGGER = LoggerFactory.getLogger(Generator.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(Generator.class);
 
     private Map<String, PDSObject> pdsObjects ;
     private Template template;

--- a/src/main/java/gov/nasa/pds/imaging/generate/label/ItemNode.java
+++ b/src/main/java/gov/nasa/pds/imaging/generate/label/ItemNode.java
@@ -35,8 +35,11 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.apache.commons.lang.StringEscapeUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ItemNode extends ArrayList<String>{
+	private static final Logger LOGGER = LoggerFactory.getLogger(ItemNode.class.getName());
 
     private String name;
     public String units;
@@ -90,7 +93,14 @@ public class ItemNode extends ArrayList<String>{
     		return "";
     	}
     	
-    	return super.get(index);
+    	
+    	try {
+    		return super.get(index);
+    	} catch (IndexOutOfBoundsException e) {
+    		LOGGER.error(String.format("IndexOutOfBoundsException: %s[%d] does not exist. %d values found.", this.name, index, this.size()));
+    	}
+
+    	return "";
     }
     
     @Override

--- a/src/main/java/gov/nasa/pds/imaging/generate/label/ItemNode.java
+++ b/src/main/java/gov/nasa/pds/imaging/generate/label/ItemNode.java
@@ -39,7 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ItemNode extends ArrayList<String>{
-	private static final Logger LOGGER = LoggerFactory.getLogger(ItemNode.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(ItemNode.class);
 
     private String name;
     public String units;

--- a/src/main/java/gov/nasa/pds/imaging/generate/label/PDS3Label.java
+++ b/src/main/java/gov/nasa/pds/imaging/generate/label/PDS3Label.java
@@ -39,8 +39,13 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.imageio.stream.ImageInputStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
+
+import gov.nasa.pds.imaging.generate.Generator;
 import gov.nasa.pds.imaging.generate.TemplateException;
 import gov.nasa.pds.imaging.generate.collections.PDSTreeMap;
 import gov.nasa.pds.imaging.generate.context.ContextUtil;
@@ -60,7 +65,8 @@ import gov.nasa.pds.tools.label.Label;
  *
  */
 public class PDS3Label implements PDSObject {
-
+  private static final Logger LOGGER = LoggerFactory.getLogger(PDS3Label.class);
+	
   public static final String CONTEXT = "label";
   public ContextUtil ctxtUtil;
 
@@ -412,7 +418,7 @@ public class PDS3Label implements PDSObject {
 
   @Override
   public void setMappings() throws TemplateException, LabelParserException {
-	  Debugger.debug("PDS3Label.setMapping parserType = "+this.parserType);
+	  LOGGER.info("ParserType: "+this.parserType);
     if (this.parserType.equals(ParserType.VICAR)) {
       Debugger.debug("+++++++++++++++++++++++++++\n"
     		+ "PDS3Label.setMapping()\n"


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
* Improved exception handling for `IndexOutOfBounds`
* Made some upgrades to replace `System.out` and `System.err` as applicable to this ticket. Much more scrubbing needed.

## ⚙️ Test Data and/or Report
See #64

```
$ pds-generate --template ~/test/mi-label-bug/lola_900Crdr_template.xml --pds3-label ~/test/mi-label-bug/LOLARDR_230741421.LBL

[main] INFO gov.nasa.pds.imaging.generate.label.PDS3Label - ParserType: VICAR
[main] ERROR gov.nasa.pds.imaging.generate.label.ItemNode - IndexOutOfBoundsException: SOURCE_PRODUCT_ID[1] does not exist. 1 values found.
[main] INFO gov.nasa.pds.imaging.generate.Generator - New PDS4 Label: /Users/jpadams/test/mi-label-bug/LOLARDR_230741421.xml
```

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->

Resolves #64
